### PR TITLE
fixes magit commit buffer error

### DIFF
--- a/centeredpoint.el
+++ b/centeredpoint.el
@@ -6,6 +6,6 @@
   )
 
 (defun line-change ()
-  (recenter)
-  )
-
+  (when (eq (get-buffer-window)
+            (selected-window))
+    (recenter)))


### PR DESCRIPTION
as suggested from magit contributor, this fixes the issue of using this minor mode and magit. before this change magit couldn't open commit message buffer.