### PR TITLE
Add Package Heading and Provide 'centeredpoint'

### DIFF
--- a/centeredpoint.el
+++ b/centeredpoint.el
@@ -37,4 +37,6 @@
             (selected-window))
     (recenter)))
 
+(provide 'centeredpoint)
+
 ;;; centeredpoint.el ends here

--- a/centeredpoint.el
+++ b/centeredpoint.el
@@ -1,3 +1,30 @@
+;;; centeredpoint.el --- Recenter the cursor every time that it moves. -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016-2021 John Mercouris
+
+;; Author: John Mercouris
+;; Created: 16 April 2016
+;; Homepage: https://github.com/jmercouris/emacs-centered-point
+;; Keywords: convenience
+;; Package-Requires: ((emacs "19.20"))
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Code:
+
 (define-minor-mode centered-point-mode
   "Alaways center the cursor in the middle of the screen."
   :lighter "..."
@@ -9,3 +36,5 @@
   (when (eq (get-buffer-window)
             (selected-window))
     (recenter)))
+
+;;; centeredpoint.el ends here


### PR DESCRIPTION
* Added a full package heading based on the field definitions at https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html (noting the un-intuitive 'keywords' field). 

* `(provide)`'d 'centerpoint' feature to match the filename `centerpoint.el`.

Left your email out of the `Author` field; I hesitate to add anyone else's email to a document without permission, least it get read by crawlers.

Absolutely love this snippet btw, thanks a lot c: